### PR TITLE
changing receive messages to long poll by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-aws-sqs-helper",
-  "version": "2.0.42",
+  "version": "2.0.43",
   "description": "Typescript AWS SQS Helper",
   "repository": {
     "type": "git",

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -228,6 +228,7 @@ export class SQSHelper extends BaseClass implements ISQSHelper {
     visibilityTimeout?: number,
     attributeNames?: string[],
     messageAttributeNames?: string[],
+    waitTimeSeconds?: number,
   ): Promise<SQS.Message[]> {
     let allMessages: SQS.Message[] = [];
 
@@ -240,6 +241,7 @@ export class SQSHelper extends BaseClass implements ISQSHelper {
         visibilityTimeout,
         attributeNames,
         messageAttributeNames,
+        waitTimeSeconds,
       );
       if (!messages || !messages.Messages || messages.Messages.length < 1) {
         break;
@@ -256,6 +258,7 @@ export class SQSHelper extends BaseClass implements ISQSHelper {
     visibilityTimeout?: number,
     attributeNames?: string[],
     messageAttributeNames?: string[],
+    waitTimeSeconds?: number,
   ): Promise<SQS.ReceiveMessageResult> {
     const action = `${SQSHelper.name}.${this.ReceiveMessagesAsync.name}`;
     this.LogHelper.LogInputs(action, {
@@ -264,6 +267,7 @@ export class SQSHelper extends BaseClass implements ISQSHelper {
       visibilityTimeout,
       attributeNames,
       messageAttributeNames,
+      waitTimeSeconds,
     });
 
     // guard clauses
@@ -281,6 +285,9 @@ export class SQSHelper extends BaseClass implements ISQSHelper {
     if (!attributeNames || attributeNames.length === 0) {
       attributeNames = ['ALL'];
     }
+    if (!waitTimeSeconds) {
+      waitTimeSeconds = 20;
+    }
 
     // create params object
     const params: SQS.ReceiveMessageRequest = {
@@ -289,6 +296,7 @@ export class SQSHelper extends BaseClass implements ISQSHelper {
       MessageAttributeNames: messageAttributeNames,
       QueueUrl: queueUrl,
       VisibilityTimeout: visibilityTimeout,
+      WaitTimeSeconds: waitTimeSeconds,
     };
     this.LogHelper.LogRequest(action, params);
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -63,12 +63,14 @@ export interface ISQSHelper {
    * @param visibilityTimeout {number} Time in seconds that a message is hidden from the queue. Default is 10
    * @param attributeNames {string[]} List of attribute names that need to be returned for each message. Default is 'ALL'
    * @param messageAttributeNames {string[]} List of message attributes to be returned for each message
+   * @param waitTimeSeconds {number} Wait time, in seconds to wait for messages. Default is 20 (long polling). Set to 0 for short polling
    */
   ReceiveAllMessagesAsync(
     queueUrl: string,
     visibilityTimeout?: number,
     attributeNames?: string[],
     messageAttributeNames?: string[],
+    waitTimeSeconds?: number,
   ): Promise<SQS.Message[]>;
 
   /**
@@ -78,6 +80,7 @@ export interface ISQSHelper {
    * @param visibilityTimeout {number} Time in seconds that a message is hidden from the queue. Default is 10
    * @param attributeNames {string[]} List of attribute names that need to be returned for each message. Default is 'ALL'
    * @param messageAttributeNames {string[]} List of message attributes to be returned for each message
+   * @param waitTimeSeconds {number} Wait time, in seconds to wait for messages. Default is 20 (long polling). Set to 0 for short polling
    */
   ReceiveMessagesAsync(
     queueUrl: string,
@@ -85,6 +88,7 @@ export interface ISQSHelper {
     visibilityTimeout?: number,
     attributeNames?: string[],
     messageAttributeNames?: string[],
+    waitTimeSeconds?: number,
   ): Promise<SQS.ReceiveMessageResult>;
 
   /**


### PR DESCRIPTION
- implements long polling by default for `ReceiveMessagesAsync` calls
- can still short poll by setting `waitTimeSeconds` to 0
- closes #245 